### PR TITLE
Add Trustabl security scanning to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're building a voice-first AI agent platform that integrates various technologies to create a comprehensive solution. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [MEDIUM] Skill fetches untrusted external content
   File: .claude/skills/server-lifecycle/SKILL.md, This skill's body references an external http(s) URL.  Accessing untrusted URLs can introduce security vulnerabilities and unexpected behavior.
2. [MEDIUM] Skill fetches untrusted external content
   File: .claude/skills/testing-patterns/SKILL.md, This skill's body references an external http(s) URL.  Accessing untrusted URLs can introduce security vulnerabilities and unexpected behavior.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)